### PR TITLE
Use Nemo.KeepAlive 1.2 for display blank prevention

### DIFF
--- a/qml/drum-machine.qml
+++ b/qml/drum-machine.qml
@@ -1,8 +1,6 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 
-import org.nemomobile.keepalive 1.1
-
 import "pages"
 import "components"
 
@@ -15,7 +13,6 @@ ApplicationWindow
     onApplicationActiveChanged: {
         if(!applicationActive){
             drum._running = false
-            DisplayBlanking.preventBlanking = false;
         }
     }
 

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -3,7 +3,7 @@ import Sailfish.Silica 1.0
 import QtMultimedia 5.0
 
 //import drum.machine.components 1.0
-import org.nemomobile.keepalive 1.1
+import Nemo.KeepAlive 1.2
 
 import "../components"
 
@@ -94,7 +94,6 @@ Page {
                 text: qsTr("Save")
                 onClicked: {
                     drum._running = false
-                    DisplayBlanking.preventBlanking = false
                     pageStack.push(Qt.resolvedUrl("SavePage.qml"))
                 }
             }
@@ -117,7 +116,6 @@ Page {
                     anchors.fill: parent
                     onClicked:{
                         drumTimer.running = !drumTimer.running;
-                        DisplayBlanking.preventBlanking = drumTimer.running;
                     }
                 }
             }
@@ -135,5 +133,10 @@ Page {
             Beat{ beat: 8 }
 
         }
+    }
+
+    DisplayBlanking {
+        id: displayBlanking
+        preventBlanking: drumTimer.running && Qt.application.state == Qt.ApplicationActive
     }
 }


### PR DESCRIPTION
The old org.nemomobile.keepalive blank prevention interface was never
officially supported 3rd party API, and has now been removed altogether.

Switch to using harbour-accepted DisplayBlanking items from
Nemo.KeepAlive 1.2.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jollamobile.com>